### PR TITLE
Fix issue with py.test, doctest, and pandas output

### DIFF
--- a/microhapdb/conftest.py
+++ b/microhapdb/conftest.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2018, Battelle National Biodefense Institute.
+#
+# This file is part of MicroHapDB (http://github.com/bioforensics/microhapdb)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+
+import pandas
+import pytest
+
+
+@pytest.fixture(autouse=True, scope='session')
+def pandas_terminal_width():
+    pandas.set_option('display.width', 1000)
+    pandas.set_option('display.max_columns', 1000)


### PR DESCRIPTION
The pandas output in some doctests was being truncated no matter how wide the terminal is. In any case, we don't want the doctests to be influenced by terminal width. See https://github.com/pytest-dev/pytest/issues/4030 for all the fun details.

This update forces pandas to assume that the terminal is very wide so that it will not truncate or wrap while printing dataframes to the terminal. This only applies to the testing environment. Printing dataframes from an interactive session will still invoke the default pandas behavior, which is probably for the best. The `microhapdb` command skirts the issue by calling the `to_string()` method when printing a dataframe.