### PR TITLE
Convenience function for accessing coordinates of locus variants

### DIFF
--- a/microhapdb/__init__.py
+++ b/microhapdb/__init__.py
@@ -20,3 +20,17 @@ allelefreqs = pandas.read_table(data_file('allele.tsv'))
 loci = pandas.read_table(data_file('locus.tsv'))
 populations = pandas.read_table(data_file('population.tsv'))
 variants = pandas.read_table(data_file('variant.tsv'))
+
+
+def allele_positions(locusid):
+    """Convenience function for grabbing a locus' genomic coordinates.
+
+    Loci can be accessed by their ALFRED IDs (SI...) or their names (mh...).
+    """
+    q = 'ID == "{id}" | Name == "{id}"'.format(id=locusid)
+    locus = loci.query(q)
+    assert len(locus) == 1
+    dbsnpids = locus['Variants'].iloc[0].split(',')
+    var = variants[variants['ID'].isin(dbsnpids)]
+    for index, row in var.iterrows():
+        yield row['Chrom'], row['Start'], row['End']

--- a/microhapdb/test_package.py
+++ b/microhapdb/test_package.py
@@ -91,3 +91,13 @@ def test_variants():
     v = microhapdb.variants
     assert v.shape == (405, 7)
     assert len(v.query('Chrom == 12')) == 15
+
+
+def test_allele_positions():
+    """
+    >>> list(microhapdb.allele_positions('mh19KK-301'))
+    [(19, 50938487, 50938488), (19, 50938502, 50938503), (19, 50938526, 50938527), (19, 50938550, 50938551)]
+    >>> list(microhapdb.allele_positions('SI664193D'))
+    [(19, 4852124, 4852125), (19, 4852324, 4852325)]
+    """
+    pass


### PR DESCRIPTION
It's important to know the coordinates not only of the locus' extent but of the variants within the locus. This update provides a convenient way to access this information.