### PR TITLE
Function for computing allele positions from microhap locus ID/Name/label

### DIFF
--- a/microhapdb/__init__.py
+++ b/microhapdb/__init__.py
@@ -11,7 +11,7 @@
 from microhapdb.util import data_file
 from microhapdb import cli
 from microhapdb import retrieve
-from microhapdb.retrieve import id_xref
+from microhapdb.retrieve import id_xref, allele_positions
 import pandas
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/microhapdb/retrieve.py
+++ b/microhapdb/retrieve.py
@@ -130,3 +130,17 @@ def fetch_by_region(region, table=None):
 
 def id_xref(idvalue):
     return next(fetch_by_id(idvalue))
+
+
+def allele_positions(locus):
+    locusrecords = microhapdb.id_xref(locus)
+    assert len(locusrecords) == 1
+    locusid = locusrecords.iloc[0].ID
+    variants = microhapdb.variants[
+        microhapdb.variants.ID.isin(
+            microhapdb.variantmap[
+                microhapdb.variantmap.LocusID == locusid
+            ].VariantID
+        )
+    ]
+    return list(variants.Position)

--- a/microhapdb/test_retrieve.py
+++ b/microhapdb/test_retrieve.py
@@ -166,6 +166,7 @@ def test_fetch_by_region():
                                           'MHDBV000009401', 'MHDBV000009402',
                                           'MHDBV000009403']
 
+
 @pytest.mark.parametrize('locusaccession', [
     'mh13KK-218',
     'SI664607D',

--- a/microhapdb/test_retrieve.py
+++ b/microhapdb/test_retrieve.py
@@ -165,3 +165,14 @@ def test_fetch_by_region():
     assert list(results[1].ID.values) == ['MHDBV000009399', 'MHDBV000009400',
                                           'MHDBV000009401', 'MHDBV000009402',
                                           'MHDBV000009403']
+
+@pytest.mark.parametrize('locusaccession', [
+    'mh13KK-218',
+    'SI664607D',
+    'MHDBL000060',
+])
+def test_allele_positions(locusaccession):
+    pos = microhapdb.retrieve.allele_positions(locusaccession)
+    assert pos == [53486691, 53486745, 53486756, 53486836]
+    with pytest.raises(StopIteration):
+        _ = microhapdb.retrieve.allele_positions('b0GusId')


### PR DESCRIPTION
This update provides a new convenience function for computing the absolute chromosomal position of each variant allele associated with a particular microhap locus. Closes #16.