### PR TITLE
New defaults for delta/minlength params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - 26 global populations from the 1000 Genomes Project migrated from ALFRED data source to a dedicated 1KGP data source (see #45).
 - Dropped Travis CI configuration (see #47).
+- Changed default delta from 25 to 10 and default minlength from 250 to 80 (see #52).
 
 
 ## [0.4.3] 2019-11-05

--- a/microhapdb/cli/marker.py
+++ b/microhapdb/cli/marker.py
@@ -35,13 +35,13 @@ def subparser(subparsers):
         help='disable truncation of tabular results'
     )
     subparser.add_argument(
-        '--delta', metavar='D', type=int, default=25, help='extend D nucleotides beyond the '
+        '--delta', metavar='D', type=int, default=10, help='extend D nucleotides beyond the '
         'marker extent when computing amplicon boundaries (detail and fasta format only); by '
-        'default D=25'
+        'default D=10'
     )
     subparser.add_argument(
-        '--min-length', metavar='L', type=int, default=250, help='minimum amplicon length (detail '
-        'and fasta format only); by default L=250'
+        '--min-length', metavar='L', type=int, default=80, help='minimum amplicon length (detail '
+        'and fasta format only); by default L=80'
     )
     subparser.add_argument(
         '-p', '--panel', metavar='FILE', help='file containing a list of marker names/identifiers,'

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -14,7 +14,7 @@ import pandas
 
 
 class TargetAmplicon():
-    def __init__(self, marker, delta=25, minlen=250):
+    def __init__(self, marker, delta=10, minlen=80):
         if isinstance(marker, str):
             markerids = standardize_ids([marker])
             assert len(markerids) == 1
@@ -311,13 +311,13 @@ def print_table(table, delta=None, minlen=None, trunc=True):
         pandas.set_option('display.max_colwidth', colwidth)
 
 
-def print_fasta(table, delta=25, minlen=250, trunc=None):
+def print_fasta(table, delta=10, minlen=80, trunc=None):
     for n, row in table.iterrows():
         amplicon = TargetAmplicon(row, delta=delta, minlen=minlen)
         print(amplicon.fasta)
 
 
-def print_detail(table, delta=25, minlen=250, trunc=None):
+def print_detail(table, delta=10, minlen=80, trunc=None):
     for n, row in table.iterrows():
         amplicon = TargetAmplicon(row, delta=delta, minlen=minlen)
         print(amplicon)

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -138,8 +138,26 @@ def test_main_marker_query(capsys):
     assert testout.strip() == out.strip()
 
 
-def test_main_marker_fasta(capsys):
-    args = get_parser().parse_args(['marker', '--format=fasta', 'mh13CP-010', 'mh08PK-46625'])
+def test_main_marker_fasta_default_delta(capsys):
+    args = get_parser().parse_args(['marker', '--format=fasta', 'mh01CP-016', 'mh06PK-24844'])
+    microhapdb.cli.main(args)
+    out, err = capsys.readouterr()
+    testout = '''
+>mh01CP-016 PermID=MHDBM-021e569a GRCh38:chr1:55559012-55559056 variants=18,56,62 Xref=SI664876L
+TGGCACACAACAAGTGCTTATAATGAAAGCATTAGTGAGTAAAAGAGTGATCCCTGGCTTTGAACTCCCTCTAAGTGTAC
+C
+>mh06PK-24844 PermID=MHDBM-aa39cbba GRCh38:chr6:13861392-13861446 variants=13,20,35,42,51,55,59,60,61,67
+AGGAAGAAAGTGATTACATCCAAACGTGAGCAGGAGGAAACTCGGAACATACTGTTTTTAAGAACTAGTATCACTAGAGT
+T
+'''
+    print(out)
+    assert testout.strip() == out.strip()
+
+
+def test_main_marker_fasta_long_delta(capsys):
+    args = get_parser().parse_args([
+        'marker', '--format=fasta', '--delta=25', '--min-length=250', 'mh13CP-010', 'mh08PK-46625'
+    ])
     microhapdb.cli.main(args)
     out, err = capsys.readouterr()
     testout = '''
@@ -240,7 +258,7 @@ def test_main_frequency_by_pop(pop, marker, allele, numrows, capsys):
     'beta',
 ])
 def test_main_panel(panel, capsys):
-    arglist = ['marker', '--panel', panel, '--format=fasta']
+    arglist = ['marker', '--panel', panel, '--format=fasta', '--delta=25', '--min-length=250']
     args = get_parser().parse_args(arglist)
     microhapdb.cli.main(args)
     terminal = capsys.readouterr()


### PR DESCRIPTION
This update introduces new defaults for the delta and minlength parameters for `microhapdb marker`. These new defaults are optimized for viewing data in a terminal window, but are still easily overridden to if needed during amplicon design. Closes #50.