### PR TITLE
Fix marker detail view

### DIFF
--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -11,6 +11,7 @@ from math import ceil
 import microhapdb
 from microhapdb.retrieve import id_in_series
 import pandas
+import sys
 
 
 class TargetAmplicon():
@@ -334,4 +335,10 @@ def print_fasta(table, delta=10, minlen=80, trunc=None):
 def print_detail(table, delta=10, minlen=80, trunc=None):
     for n, row in table.iterrows():
         amplicon = TargetAmplicon(row, delta=delta, minlen=minlen)
+        if len(amplicon.alleles) == 0:
+            print(
+                '[MicroHapDB::marker] Unable to display a full detail view for markers without '
+                'frequency information', file=sys.stderr
+            )
+            return
         print(amplicon)

--- a/microhapdb/tests/test_marker.py
+++ b/microhapdb/tests/test_marker.py
@@ -64,7 +64,7 @@ def test_marker_table(capsys):
 
 
 def test_marker_table_multi(capsys):
-    markers = microhapdb.markers.query('Name.str.contains("PK")').head(n=5)
+    markers = microhapdb.markers.query('Name.str.contains("PK")', engine='python').head(n=5)
     microhapdb.marker.print_table(markers)
     testout = '''
          Name          PermID Reference  Chrom                                            Offsets      Ae      In     Fst                        Source
@@ -88,7 +88,7 @@ def test_marker_table_multi(capsys):
 
 
 def test_marker_table_multi_notrunc(capsys):
-    markers = microhapdb.markers.query('Name.str.contains("PK")').head(n=5)
+    markers = microhapdb.markers.query('Name.str.contains("PK")', engine='python').head(n=5)
     microhapdb.marker.print_table(markers, trunc=False)
     testoutlong = '''
          Name          PermID Reference  Chrom                                                                                    Offsets      Ae      In     Fst                        Source
@@ -517,3 +517,12 @@ def test_set_reference():
         microhapdb.set_reference(38)
         result = microhapdb.retrieve.by_region('chr18:20000000-25000000')
         assert result.Offsets.tolist() == coords38
+
+
+@pytest.mark.parametrize('markername', ['mh0XUSC-XqD'])
+def test_marker_no_freq(markername, capsys):
+    marker = microhapdb.markers[microhapdb.markers.Name == markername]
+    microhapdb.marker.print_detail(marker)
+    terminal = capsys.readouterr()
+    message = 'Unable to display a full detail view for markers without frequency information'
+    assert message in terminal.err

--- a/microhapdb/tests/test_population.py
+++ b/microhapdb/tests/test_population.py
@@ -44,7 +44,7 @@ def test_populations():
     31         SA000009J                            Han                        ALFRED
     32               CHB  Han Chinese in Beijing, China                          1KGP
     88               CHS           Southern Han Chinese                          1KGP
-    >>> p.query('Name.str.contains("Afr")')
+    >>> p.query('Name.str.contains("Afr")', engine='python')
                      ID                                     Name                        Source
     1  MHDBP-3dab7bdd14                                   Africa  10.1016/j.fsigen.2018.05.008
     2         SA000101C                        African Americans                        ALFRED


### PR DESCRIPTION
This update addresses #66. MicroHapDB will now emit a warning message when a user attempts to display the "detail" view for a marker with no frequency information. At the moment, there is only a single marker (mh0XUSC-XqD) with no frequency data in MicroHapDB. (This marker includes SNPs without RSIDs, so 1000 Genomes data could not be used to compute allele frequencies. Four other markers also include variants without RSIDs, but these were published with a study that included its own frequency data.)

Numerous markers from #57 include SNPs with no RSID. Unless the frequency information from this study can be easily obtained, these markers will also have no frequency/observed haplotype information and will not be displayable in the marker detail view.

Fixes #66.