### PR TITLE
Allow user to extend 5' end, 3' end, or symmetrically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Markers and population frequency data (1000 Genomes and proprietary) for the mMHseq 90-plex panel (see #68).
+- New `--extend-mode` option when displaying markers in `fasta` or `detail` mode (see #72).
 
 ### Fixed
 - Error message when detail view is requested for a marker without frequency information (see #67).

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -15,11 +15,12 @@ import sys
 
 
 class TargetAmplicon():
-    def __init__(self, marker, delta=10, minlen=80):
+    def __init__(self, marker, delta=10, minlen=80, extendmode=0):
         if isinstance(marker, str):
             markerids = standardize_ids([marker])
             assert len(markerids) == 1
             marker = microhapdb.markers[microhapdb.markers.Name.isin(markerids)].iloc[0]
+        self.extendmode = int(extendmode)
         self.data = marker
         self.delta = delta
         self.minlen = minlen
@@ -99,9 +100,14 @@ class TargetAmplicon():
         length = end - start
         if length < self.minlen:
             diff = self.minlen - length
-            extension = ceil(diff / 2)
-            start -= extension
-            end += extension
+            if self.extendmode < 0:
+                start -= diff
+            elif self.extendmode > 0:
+                end += diff
+            else:
+                extension = ceil(diff / 2)
+                start -= extension
+                end += extension
         return start, end
 
     @property
@@ -317,7 +323,7 @@ def standardize_ids(idents):
     return microhapdb.markers[microhapdb.markers.Name.isin(ids)].Name
 
 
-def print_table(table, delta=None, minlen=None, trunc=True):
+def print_table(table, trunc=True):
     if trunc is not True:
         colwidth = pandas.get_option('display.max_colwidth')
         pandas.set_option('display.max_colwidth', 1000000)
@@ -326,15 +332,15 @@ def print_table(table, delta=None, minlen=None, trunc=True):
         pandas.set_option('display.max_colwidth', colwidth)
 
 
-def print_fasta(table, delta=10, minlen=80, trunc=None):
+def print_fasta(table, delta=10, minlen=80, extendmode=0):
     for n, row in table.iterrows():
-        amplicon = TargetAmplicon(row, delta=delta, minlen=minlen)
+        amplicon = TargetAmplicon(row, delta=delta, minlen=minlen, extendmode=extendmode)
         print(amplicon.fasta)
 
 
-def print_detail(table, delta=10, minlen=80, trunc=None):
+def print_detail(table, delta=10, minlen=80, extendmode=0):
     for n, row in table.iterrows():
-        amplicon = TargetAmplicon(row, delta=delta, minlen=minlen)
+        amplicon = TargetAmplicon(row, delta=delta, minlen=minlen, extendmode=extendmode)
         if len(amplicon.alleles) == 0:
             print(
                 '[MicroHapDB::marker] Unable to display a full detail view for markers without '

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -238,6 +238,47 @@ def test_main_marker_panel_region_conflict(capsys):
     assert 'ignoring user-supplied marker IDs in --region mode' in terminal.err
 
 
+@pytest.mark.parametrize('mode,offsets1,offsets2', [
+    ('symmetric', 'variants=70,92,104', 'variants=47,82,128'),
+    ('5', 'variants=120,142,154', 'variants=73,108,154'),
+    ('3', 'variants=20,42,54', 'variants=20,55,101'),
+])
+def test_main_marker_extendmode(mode, offsets1, offsets2, capsys):
+    arglist = [
+        'marker', '--format', 'fasta', '--extend-mode', mode, '--delta', '20',
+        '--min-length', '175', 'mh01USC-1pD', 'mh22NH-27'
+    ]
+    args = get_parser().parse_args(arglist)
+    microhapdb.cli.main(args)
+    terminal = capsys.readouterr()
+    assert offsets1 in terminal.out
+    assert offsets2 in terminal.out
+
+
+@pytest.mark.parametrize('mode', ['4', '6', 'NotARealMode'])
+def test_main_marker_extendmode_bad(mode, capsys):
+    arglist = [
+        'marker', '--format', 'fasta', '--extend-mode', mode, '--delta', '20',
+        '--min-length', '175', 'mh01USC-1pD', 'mh22NH-27'
+    ]
+    with pytest.raises(SystemExit):
+        args = get_parser().parse_args(arglist)
+    terminal = capsys.readouterr()
+    assert 'invalid str_to_extend_mode value' in terminal.err
+
+
+def test_main_marker_view_bad():
+    arglist = [
+        'marker', '--format', 'fasta', '--extend-mode', '5', '--delta', '20',
+        '--min-length', '175', 'mh01USC-1pD', 'mh22NH-27'
+    ]
+    args = get_parser().parse_args(arglist)
+    args.format = 'html'
+    with pytest.raises(ValueError, match=r'unsupported view format "html"'):
+        microhapdb.cli.main(args)
+
+
+
 @pytest.mark.parametrize('pop,marker,allele,numrows', [
     ('--population=Swedish', None, None, 138),
     ('--population=SA000009J', '--marker=mh13KK-218', None, 15),

--- a/microhapdb/tests/test_marker.py
+++ b/microhapdb/tests/test_marker.py
@@ -556,3 +556,24 @@ def test_marker_no_freq(markername, capsys):
     terminal = capsys.readouterr()
     message = 'Unable to display a full detail view for markers without frequency information'
     assert message in terminal.err
+
+
+@pytest.mark.parametrize('mode,offsets1,offsets2', [
+    (0, 'variants=70,92,104', 'variants=47,82,128'),
+    (-1, 'variants=120,142,154', 'variants=73,108,154'),
+    (1, 'variants=20,42,54', 'variants=20,55,101'),
+])
+def test_marker_extendmode(mode, offsets1, offsets2, capsys):
+    markers = microhapdb.markers[microhapdb.markers.Name.isin(['mh01USC-1pD', 'mh22NH-27'])]
+    microhapdb.marker.print_fasta(markers, delta=20, minlen=175, extendmode=mode)
+    terminal = capsys.readouterr()
+    assert offsets1 in terminal.out
+    assert offsets2 in terminal.out
+
+
+def test_marker_extendmode_bad():
+    markers = microhapdb.markers[microhapdb.markers.Name.isin(['mh01USC-1pD', 'mh22NH-27'])]
+    with pytest.raises(ValueError, match=r'invalid literal for int'):
+        microhapdb.marker.print_fasta(markers, delta=20, minlen=175, extendmode="NotAnInt")
+    with pytest.raises(TypeError, match=r'argument must be a string'):
+        microhapdb.marker.print_fasta(markers, delta=20, minlen=175, extendmode=None)


### PR DESCRIPTION
Currently, when displaying markers in `detail` or `fasta` mode, if a marker is shorter than `--min-length`, MicroHapDB will extend the marker coordinates symmetrically to satisfy the minimum length. This PR gives the user the option to extend just the 5' end or just the 3' end instead (symmetric is still the default).