### PR TITLE
Add options for preparing MicroHapulator input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Markers and population frequency data (1000 Genomes and proprietary) for the mMHseq 90-plex panel (see #68).
 - New `--extend-mode` option when displaying markers in `fasta` or `detail` mode (see #72).
+- New options for preparing MicroHapDB data for import into MicroHapulator (see #80).
 
 ### Changed
 - Support for pandas>=1.2 added, support for Python 3.6 dropped (see #74).

--- a/microhapdb/cli/marker.py
+++ b/microhapdb/cli/marker.py
@@ -7,7 +7,7 @@
 
 from argparse import RawDescriptionHelpFormatter
 import microhapdb
-from microhapdb.marker import print_detail, print_table, print_fasta
+from microhapdb.marker import print_detail, print_table, print_fasta, print_offsets
 from textwrap import dedent
 import sys
 
@@ -41,7 +41,7 @@ def subparser(subparsers):
     subparser = subparsers.add_parser(
         'marker', description=desc, epilog=epilog, formatter_class=RawDescriptionHelpFormatter,
     )
-    subparser.add_argument('--format', choices=['table', 'detail', 'fasta'], default='table')
+    subparser.add_argument('--format', choices=['table', 'detail', 'fasta', 'offsets'], default='table')
     subparser.add_argument(
         '--ae-pop', metavar='POP', help='specify the 1000 Genomes population from which to report '
         'effective number of alleles in the "Ae" column; by default, the Ae value averaged over '
@@ -119,6 +119,8 @@ def main(args):
         print_detail(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode)
     elif args.format == 'fasta':
         print_fasta(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode)
+    elif args.format == 'offsets':
+        print_offsets(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode)
     else:
         raise ValueError(f'unsupported view format "{args.format}"')
     if args.ae_pop:

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -348,3 +348,13 @@ def print_detail(table, delta=10, minlen=80, extendmode=0):
             )
             return
         print(amplicon)
+
+
+def print_offsets(table, delta=10, minlen=80, extendmode=0):
+    offsets = list()
+    for n, row in table.iterrows():
+        amplicon = TargetAmplicon(row, delta=delta, minlen=minlen, extendmode=extendmode)
+        for offset in amplicon.amplicon_offsets:
+            offsets.append([row.Name, offset])
+    offsetsdf = pandas.DataFrame(offsets, columns=["Marker", "Offset"])
+    offsetsdf.to_csv(sys.stdout, sep="\t", index=False)

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -7,9 +7,11 @@
 # and is licensed under the BSD license: see LICENSE.txt.
 # -----------------------------------------------------------------------------
 
+from io import StringIO
 import microhapdb
 from microhapdb.cli import get_parser
 from microhapdb.util import data_file
+import pandas
 import pytest
 from tempfile import NamedTemporaryFile
 
@@ -436,3 +438,18 @@ mh18KKCS-293 MHDBM-350bd971    GRCh37 chr18 76089731,76089843,76089884,76089885,
     obs_out = terminal.out
     print(obs_out)
     assert exp_out.strip() == obs_out.strip()
+
+
+def test_marker_offsets_cli(capsys):
+    arglist = [
+        'marker', '--format=offsets', '--delta=25', '--min-length=200', 'mh03AT-09', 'mh11KK-180',
+        'mh13KK-217', 'mh07USC-7qC'
+    ]
+    args = get_parser().parse_args(arglist)
+    microhapdb.cli.main(args)
+    terminal = capsys.readouterr()
+    result = pandas.read_csv(StringIO(terminal.out), sep='\t')
+    assert result.shape == (15, 2)
+    observed = list(result.Offset)
+    expected = [85, 114, 66, 95, 122, 123, 134, 25, 145, 203, 218, 25, 65, 179, 217]
+    assert observed == expected

--- a/microhapdb/tests/test_marker.py
+++ b/microhapdb/tests/test_marker.py
@@ -6,8 +6,10 @@
 # -----------------------------------------------------------------------------
 
 
+from io import StringIO
 import microhapdb
 from microhapdb.marker import standardize_ids
+import pandas
 import pytest
 
 
@@ -578,3 +580,15 @@ def test_marker_extendmode_bad():
         microhapdb.marker.print_fasta(markers, delta=20, minlen=175, extendmode="NotAnInt")
     with pytest.raises(TypeError, match=r'argument must be a string'):
         microhapdb.marker.print_fasta(markers, delta=20, minlen=175, extendmode=None)
+
+
+def test_marker_offsets(capsys):
+    ids = ['mh03AT-09', 'mh11KK-180', 'mh13KK-217', 'mh07USC-7qC']
+    markers = microhapdb.markers[microhapdb.markers.Name.isin(ids)]
+    microhapdb.marker.print_offsets(markers, delta=25, minlen=200)
+    terminal = capsys.readouterr()
+    result = pandas.read_csv(StringIO(terminal.out), sep='\t')
+    assert result.shape == (15, 2)
+    observed = list(result.Offset)
+    expected = [85, 114, 66, 95, 122, 123, 134, 25, 145, 203, 218, 25, 65, 179, 217]
+    assert observed == expected


### PR DESCRIPTION
MicroHapulator was recently updated to remove its dependency on MicroHapDB for marker definitions, reference sequences, and population frequencies. Instead, these must now be passed to MicroHapulator as TSV and FASTA files. This PR implements a handful of new options to assist in preparing those files.