### PR TITLE
Support multiple filters, panel file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Support for pandas>=1.2 added, support for Python 3.6 dropped (see #74).
+- The `--marker` and `--population` flags for `microhapdb frequency` now support multiple arguments (see #81).
 
 ### Fixed
 - Error message when detail view is requested for a marker without frequency information (see #67).


### PR DESCRIPTION
This PR updates the `microhapdb frequency` command so that the `--marker` and `--population` flags accept multiple arguments, and adds a new `--panel` flag for filtering by marker names stored in a separate file.