### PR TITLE
Formatting frequencies for probgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Markers and population frequency data (1000 Genomes and proprietary) for the mMHseq 90-plex panel (see #68).
 - New `--extend-mode` option when displaying markers in `fasta` or `detail` mode (see #72).
 - New options for preparing MicroHapDB data for import into MicroHapulator (see #80).
+- New option for preparing MicroHapDB frequency data for import into probgen tools like LRMix Studio or EuroForMix (see #82).
 
 ### Changed
 - Support for pandas>=1.2 added, support for Python 3.6 dropped (see #74).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Install with bioconda][condabadge]](http://bioconda.github.io/recipes/microhapdb/README.html)
 [![BSD licensed][licensebadge]](https://github.com/bioforensics/MicroHapDB/blob/master/LICENSE.txt)
 
-Daniel Standage, 2018-2021  
+Daniel Standage, 2018-2022
 https://github.com/bioforensics/microhapdb
 
 **MicroHapDB** is a portable database intended for scientists and researchers interested in microhaplotypes for forensic analysis.

--- a/microhapdb/cli/frequency.py
+++ b/microhapdb/cli/frequency.py
@@ -8,6 +8,8 @@
 from argparse import RawDescriptionHelpFormatter
 import microhapdb
 from microhapdb.retrieve import standardize_marker_ids, standardize_population_ids
+from numpy import float64
+import pandas as pd
 import sys
 from textwrap import dedent
 
@@ -24,12 +26,54 @@ def subparser(subparsers):
     subparser = subparsers.add_parser(
         'frequency', description=desc, epilog=epilog, formatter_class=RawDescriptionHelpFormatter,
     )
-    subparser.add_argument('--format', choices=['table', 'detail', 'mhpl8r'], default='table')
+    subparser.add_argument('--format', choices=['table', 'detail', 'mhpl8r', 'efm'], default='table')
     meg = subparser.add_mutually_exclusive_group()
     meg.add_argument('--marker', metavar='ID', nargs='+', help='restrict frequencies by marker')
     meg.add_argument('--panel', metavar='FILE', help='restrict frequencies to markers listed in FILE, one ID per line')
     subparser.add_argument('--population', metavar='ID', nargs='+', help='restrict frequencies by population')
     subparser.add_argument('--allele', metavar='ID', help='restrict frequencies by allele')
+
+
+def order_haplotypes(markers, pop, frequencies):
+    """Retrieve all unique haplotype designators and order by marker occurrence
+
+    This ordering creates a pleasing arrangement of blocks of data along a single diagonal in the
+    final output table, whereas other orderings result in a more chaotic organization.
+    """
+    haplotypes = list()
+    for marker in sorted(markers):
+        # print("DEBUG", frequencies.shape, len(frequencies.Marker == marker), len(frequencies.Population))
+        subset = frequencies[(frequencies.Marker == marker) & (frequencies.Population == pop)]
+        for haplotype in sorted(subset.Allele):
+            if haplotype not in haplotypes:
+                haplotypes.append(haplotype)
+    print(
+        f"[microhapdb] retrieved and ordered {len(haplotypes)} distinct haplotypes",
+        file=sys.stderr,
+    )
+    return haplotypes
+
+
+def construct_frequency_table(pop, panel):
+    frequencies = microhapdb.frequencies
+    frequencies = frequencies[frequencies.Marker.isin(panel)]
+    marker_indices = {marker: i for i, marker in enumerate(panel)}
+    haplotypes = order_haplotypes(panel, pop, frequencies)
+    table = pd.DataFrame(index=haplotypes, columns=sorted(panel), dtype=float64)
+    table.index.name = "Allele"
+    for haplotype in haplotypes:
+        hapfreqs = [None] * len(panel)
+        subset = frequencies[(frequencies.Allele == haplotype) & (frequencies.Population == pop)]
+        for j, row in subset.iterrows():
+            index = marker_indices[row.Marker]
+            hapfreqs[index] = row.Frequency
+        table.loc[haplotype] = hapfreqs
+    nrows, ncols = table.shape
+    print(
+        f"[microhapdb] constructed frequency table for {nrows} haplotypes and {ncols} markers",
+        file=sys.stderr,
+    )
+    return table.round(3)
 
 
 def main(args):
@@ -41,6 +85,7 @@ def main(args):
     if args.panel:
         with open(args.panel, 'r') as fh:
             markerids = fh.read().strip().split()
+            markerids = standardize_marker_ids(markerids)
         result = result[result.Marker.isin(markerids)]
     if args.population:
         popids = standardize_population_ids(args.population)
@@ -57,5 +102,10 @@ def main(args):
             print(f'warning: frequencies for {npop} populations recovered, expected only 1', file=sys.stderr)
         result = result[['Marker', 'Allele', 'Frequency']].rename(columns={'Allele': 'Haplotype'})
         result.to_csv(sys.stdout, sep="\t", index=False)
+    elif args.format == 'efm':
+        if args.population is None or len(args.population) != 1:
+            raise ValueError("must specify one and only one population for --format=efm")
+        result = construct_frequency_table(args.population[0], markerids)
+        result.to_csv(sys.stdout)
     else:
         raise ValueError(f'unsupported view format "{args.format}"')

--- a/microhapdb/cli/frequency.py
+++ b/microhapdb/cli/frequency.py
@@ -104,7 +104,7 @@ def main(args):
         result.to_csv(sys.stdout, sep="\t", index=False)
     elif args.format == 'efm':
         if args.population is None or len(args.population) != 1:
-            raise ValueError("must specify one and only one population for --format=efm")
+            raise ValueError("must specify one and only one population with --format=efm")
         result = construct_frequency_table(args.population[0], markerids)
         result.to_csv(sys.stdout)
     else:

--- a/microhapdb/tests/test_frequency.py
+++ b/microhapdb/tests/test_frequency.py
@@ -117,6 +117,33 @@ def test_mhpl8r_multi_pop(capsys):
     assert 'warning: frequencies for 4 populations recovered, expected only 1' in terminal.err
 
 
+def test_efm(capsys):
+    arglist = [
+        'frequency', '--population=CEU', '--format=efm', '--marker', 'mh01USC-1pD', 'mh17USC-17pA',
+        'mh15USC-15qA'
+    ]
+    args = microhapdb.cli.get_parser().parse_args(arglist)
+    microhapdb.cli.frequency.main(args)
+    terminal = capsys.readouterr()
+    result = pandas.read_csv(StringIO(terminal.out))
+    print(result)
+    assert result.shape == (13, 4)
+    assert result['Allele'].iloc[3] == "C,T,C"
+    assert result['mh01USC-1pD'].iloc[3] == pytest.approx(0.101)
+    assert pandas.isna(result['mh15USC-15qA'].iloc[3])
+    assert result['mh17USC-17pA'].iloc[3] == pytest.approx(0.02)
+
+
+def test_efm_multi_pop():
+    arglist = [
+        'frequency', '--population', 'CEU', 'IBS', '--format=efm', '--marker', 'mh01USC-1pD',
+        'mh17USC-17pA', 'mh15USC-15qA'
+    ]
+    args = microhapdb.cli.get_parser().parse_args(arglist)
+    with pytest.raises(ValueError, match="must specify one and only one population with --format=efm"):
+        microhapdb.cli.frequency.main(args)
+
+
 def test_bad_format():
     arglist = ['frequency', '--marker', 'mh02USC-2pA', '--population', 'JPT', '--format', 'detail']
     args = microhapdb.cli.get_parser().parse_args(arglist)


### PR DESCRIPTION
This PR adds a new `--format=emf` option to `microhapdb frequency` to print out a frequency table in a format that is compatible with LRMix Studio and EuroForMix.