### PR TITLE
Add GRCh38 offsets to marker --format=offsets output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ scratch/
 .snakemake/
 .DS_Store
 coverage.xml
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- 25 marker definitions from Sun et al 2020 (see #87).
+- 23 marker definitions from Jin et al 2020 (see #89).
+- 20 marker definitions from Kureshi et al 2020 (see #90).
+- GRCh38 offsets to `microhapdb marker --format=offsets` (see #92).
+
+## Changed
+- Minor improvements to database build and corresponding documentation (see #88).
+
+
 ## [0.7] 2022-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Install with bioconda][condabadge]](http://bioconda.github.io/recipes/microhapdb/README.html)
 [![BSD licensed][licensebadge]](https://github.com/bioforensics/MicroHapDB/blob/master/LICENSE.txt)
 
-Daniel Standage, 2018-2022
+NBFAC, 2018-2022
 https://github.com/bioforensics/microhapdb
 
 **MicroHapDB** is a portable database intended for scientists and researchers interested in microhaplotypes for forensic analysis.
-The database includes a comprehensive collection of marker and allele frequency data from numerous databases and published research articles.<sup>[5-16]</sup>
+The database includes a comprehensive collection of marker and allele frequency data from numerous databases and published research articles.<sup>[5-18]</sup>
 Effective number of allele (*A<sub>e</sub>*)<sup>[2]</sup> and informativeness for assignment (*I<sub>n</sub>*)<sup>[3]</sup> statistics are included so that markers can be ranked for different forensic applications.
 The entire contents of the database are distributed with each copy of MicroHapDB, and instructions for adding private data to a local copy of the database are provided.
 MicroHapDB is designed to be user-friendly for both practitioners and researchers, supporting a range of access methods from browsing to simple text queries to complex queries to full programmatic access via a Python API.
@@ -127,6 +127,9 @@ If you use this database, please cite our work.
 
 > Standage DS,  Mitchell RN (2020) MicroHapDB: A Portable and Extensible Database of All Published Microhaplotype Marker and Frequency Data. *Frontiers in Genetics* 11:781, [doi:10.3389/fgene.2020.00781](https://doi.org/10.3389/fgene.2020.00781).
 
+MicroHapDB was created and is maintained by the Bioinformatics Group at the National Bioforensic Anaylsis Center (NBFAC).
+
+
 ----------
 
 
@@ -169,6 +172,10 @@ If you use this database, please cite our work.
 <sup>[15]</sup>Gandotra N, Speed WC, Qin W, Tang Y, Pakstis AJ, Kidd KK, Scharfe C (2020) Validation of novel forensic DNA markers using multiplex microhaplotype sequencing. *Forensic Science International: Genetics*, **47**:102275, [doi:10.1016/j.fsigen.2020.102275](https://doi.org/10.1016/j.fsigen.2020.102275).
 
 <sup>[16]</sup>Sun S, Liu Y, Li J, Yang Z, Wen D, Liang W, Yan Y, Yu H, Cai J, Zha L (2020) Development and application of a nonbinary SNP-based microhaplotype panel for paternity testing involving close relatives. *FSI: Genetics*, 46:102255, [doi:10.1016/j.fsigen.2020.102255](https://doi.org/10.1016/j.fsigen.2020.102255).
+
+<sup>[17]</sup>Kureshi A, Li J, Wen D, Sun S, Yang Z, Zha L (2020) Construction and forensic application of 20 highly polymorphic microhaplotypes. *Royal Society Open Science*, **7**(5):191937, [doi:10.1098/rsos.191937](https://doi.org/10.1098/rsos.191937).
+
+<sup>[18]</sup>Jin XY, Cui W, Chen C, Guo YX, Zhang XR, Xing GH, Lan JW, Zhu BF (2020) Developing and population analysis of a new multiplex panel of 18 microhaplotypes and compound markers using next generation sequencing and its application in the Shaanxi Han population. *Electrophoresis*, **41**(13-14):1230-1237, [doi:10.1002/elps.201900451](https://doi.org/10.1002/elps.201900451).
 
 [alfred]: https://alfred.med.yale.edu/alfred/alfredDataDownload.asp
 [Pandas]: https://pandas.pydata.org

--- a/microhapdb/cli/marker.py
+++ b/microhapdb/cli/marker.py
@@ -120,7 +120,8 @@ def main(args):
     elif args.format == 'fasta':
         print_fasta(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode)
     elif args.format == 'offsets':
-        print_offsets(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode)
+        refr = "Hg37" if args.GRCh37 else "Hg38"
+        print_offsets(result, delta=args.delta, minlen=args.min_length, extendmode=args.extend_mode, refr=refr)
     else:
         raise ValueError(f'unsupported view format "{args.format}"')
     if args.ae_pop:

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -354,7 +354,7 @@ def print_offsets(table, delta=10, minlen=80, extendmode=0):
     offsets = list()
     for n, row in table.iterrows():
         amplicon = TargetAmplicon(row, delta=delta, minlen=minlen, extendmode=extendmode)
-        for offset in amplicon.amplicon_offsets:
-            offsets.append([row.Name, offset])
-    offsetsdf = pandas.DataFrame(offsets, columns=["Marker", "Offset"])
+        for offset, offset38 in zip(amplicon.amplicon_offsets, amplicon.offsets38):
+            offsets.append([row.Name, offset, amplicon.data.Chrom, offset38])
+    offsetsdf = pandas.DataFrame(offsets, columns=["Marker", "Offset", "Chrom", "OffsetHg38"])
     offsetsdf.to_csv(sys.stdout, sep="\t", index=False)

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -350,11 +350,11 @@ def print_detail(table, delta=10, minlen=80, extendmode=0):
         print(amplicon)
 
 
-def print_offsets(table, delta=10, minlen=80, extendmode=0):
+def print_offsets(table, delta=10, minlen=80, extendmode=0, refr="Hg38"):
     offsets = list()
     for n, row in table.iterrows():
         amplicon = TargetAmplicon(row, delta=delta, minlen=minlen, extendmode=extendmode)
-        for offset, offset38 in zip(amplicon.amplicon_offsets, amplicon.offsets38):
-            offsets.append([row.Name, offset, amplicon.data.Chrom, offset38])
-    offsetsdf = pandas.DataFrame(offsets, columns=["Marker", "Offset", "Chrom", "OffsetHg38"])
+        for offset, refr_offset in zip(amplicon.amplicon_offsets, amplicon.offsets):
+            offsets.append([row.Name, offset, amplicon.data.Chrom, refr_offset])
+    offsetsdf = pandas.DataFrame(offsets, columns=["Marker", "Offset", "Chrom", f"Offset{refr}"])
     offsetsdf.to_csv(sys.stdout, sep="\t", index=False)

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -457,7 +457,13 @@ def test_marker_offsets_cli(capsys):
     microhapdb.cli.main(args)
     terminal = capsys.readouterr()
     result = pandas.read_csv(StringIO(terminal.out), sep='\t')
-    assert result.shape == (15, 2)
+    assert result.shape == (15, 4)
     observed = list(result.Offset)
     expected = [85, 114, 66, 95, 122, 123, 134, 25, 145, 203, 218, 25, 65, 179, 217]
+    assert observed == expected
+    observed = list(result.OffsetHg38)
+    expected = [
+        131927127, 131927156, 151821663, 151821692, 151821719, 151821720, 151821731, 1669560,
+        1669680, 1669738, 1669753, 46291794, 46291834, 46291948, 46291986
+    ]
     assert observed == expected

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -467,3 +467,14 @@ def test_marker_offsets_cli(capsys):
         1669680, 1669738, 1669753, 46291794, 46291834, 46291948, 46291986
     ]
     assert observed == expected
+
+
+def test_marker_offsets_37_cli(capsys):
+    arglist = ['marker', '--GRCh37', '--format=offsets', 'mh01USC-1qA', 'mh02USC-2qA', 'mh03USC-3qA']
+    args = get_parser().parse_args(arglist)
+    microhapdb.cli.main(args)
+    terminal = capsys.readouterr()
+    result = pandas.read_csv(StringIO(terminal.out), sep='\t')
+    assert result.shape == (10, 4)
+    assert list(result.columns) == ["Marker", "Offset", "Chrom", "OffsetHg37"]
+    assert list(result.OffsetHg37)[:5] == [167126967, 167126986, 103092502, 103092512, 103092574]

--- a/microhapdb/tests/test_marker.py
+++ b/microhapdb/tests/test_marker.py
@@ -589,7 +589,13 @@ def test_marker_offsets(capsys):
     microhapdb.marker.print_offsets(markers, delta=25, minlen=200)
     terminal = capsys.readouterr()
     result = pandas.read_csv(StringIO(terminal.out), sep='\t')
-    assert result.shape == (15, 2)
+    assert result.shape == (15, 4)
     observed = list(result.Offset)
     expected = [85, 114, 66, 95, 122, 123, 134, 25, 145, 203, 218, 25, 65, 179, 217]
+    assert observed == expected
+    observed = list(result.OffsetHg38)
+    expected = [
+        131927127, 131927156, 151821663, 151821692, 151821719, 151821720, 151821731, 1669560,
+        1669680, 1669738, 1669753, 46291794, 46291834, 46291948, 46291986
+    ]
     assert observed == expected


### PR DESCRIPTION
MicroHapulator recently added a new feature for reporting the extent of off-target mapping for each marker. This feature depends on having the GRCh38 coordinates for each SNP, as well as the locus coordinates that were already used. This PR updates the `microhapdb marker --format=offsets` command to include this information.