### PR TITLE
Fix dereferencing issues

### DIFF
--- a/microhapdb/cli/frequency.py
+++ b/microhapdb/cli/frequency.py
@@ -92,6 +92,8 @@ def main(args):
         result = result[result.Population.isin(popids)]
     if args.allele:
         result = result[result.Allele == args.allele]
+    if len(result) == 0:
+        return
     if args.format == 'table':
         print(result.to_string(index=False))
     elif args.format == 'detail':

--- a/microhapdb/cli/marker.py
+++ b/microhapdb/cli/marker.py
@@ -113,6 +113,10 @@ def main(args):
         result = microhapdb.markers[microhapdb.markers.Name.isin(idents)]
     else:
         result = microhapdb.markers
+    if len(result) == 0:
+        microhapdb.set_ae_population(popid=None)  # Reset
+        microhapdb.set_reference(38)  # Reset
+        return
     if args.format == 'table':
         print_table(result, trunc=args.trunc)
     elif args.format == 'detail':

--- a/microhapdb/cli/population.py
+++ b/microhapdb/cli/population.py
@@ -40,5 +40,7 @@ def main(args):
         result = microhapdb.populations[microhapdb.populations.ID.isin(idents)]
     else:
         result = microhapdb.populations
+    if len(result) == 0:
+        return
     view = print_table if args.format == 'table' else print_detail
     view(result)

--- a/microhapdb/retrieve.py
+++ b/microhapdb/retrieve.py
@@ -36,8 +36,18 @@ def standardize_marker_ids(idents):
 
 
 def standardize_population_ids(idents):
+    ids = set()
+    for ident in idents:
+        if id_in_series(ident, microhapdb.populations.ID):
+            ids.add(ident)
+        elif id_in_series(ident, microhapdb.populations.Name):
+            ids.add(ident)
+        elif id_in_series(ident, microhapdb.idmap.Xref):
+            popid = microhapdb.idmap[microhapdb.idmap.Xref == ident].ID
+            assert len(popid) == 1
+            ids.add(popid.iloc[0])
     result = microhapdb.populations[
-        (microhapdb.populations.ID.isin(idents)) | (microhapdb.populations.Name.isin(idents))
+        (microhapdb.populations.ID.isin(ids)) | (microhapdb.populations.Name.isin(ids))
     ]
     return result.ID
 

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -483,3 +483,16 @@ def test_marker_offsets_37_cli(capsys):
     assert result.shape == (10, 4)
     assert list(result.columns) == ["Marker", "Offset", "Chrom", "OffsetHg37"]
     assert list(result.OffsetHg37)[:5] == [167126967, 167126986, 103092502, 103092512, 103092574]
+
+
+@pytest.mark.parametrize("arglist", [
+    ("marker", "--GRCh37", "BogusMarkerID"),
+    ("population", "Atreides"),
+    ("frequency", "--marker=mh02USC-2pA", "--population=XYZ"),
+    ("frequency", "--marker=NotARealMarkerID", "--population=CEU"),
+])
+def test_cli_bad_ids(arglist, capsys):
+    args = get_parser().parse_args(arglist)
+    microhapdb.cli.main(args)
+    terminal = capsys.readouterr()
+    assert terminal.out == ""

--- a/microhapdb/tests/test_retrieve.py
+++ b/microhapdb/tests/test_retrieve.py
@@ -57,3 +57,9 @@ def test_marker_ids():
     assert list(standardize_marker_ids(['mh15KK-058'])) == ['mh15KK-058']
     assert list(standardize_marker_ids(['SI664549I'])) == ['mh01KK-117']
     assert list(standardize_marker_ids(['MHDBM-3d69621c'])) == ['mh11KK-040', 'mh11AT-23']
+
+
+def test_population_xref():
+    assert list(standardize_population_ids(['SA004250L'])) == ['CEU']
+    assert list(standardize_population_ids(['SA004250L', 'BogusPopID'])) == ['CEU']
+    assert list(standardize_population_ids(['SA004250L', 'Cheyenne'])) == ['SA000023F', 'CEU']


### PR DESCRIPTION
This PR touches on a couple of related issues.

First, I was unable to reproduce the bug as described in #78. Perhaps In any case, I have a regression test that ensures the desired behavior.

Second, I made some changes that allow populations to be retrieved by database cross-reference, as described in #77.

Closes #77. Closes #78.