### PR TITLE
New summarize subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Check for overlapping microhaps from different sources during the database build (#112).
 - Over 1,000 marker definitions from four whole-genome screens from Yu et al 2022 (see #115, #118).
 - New `nomenclature` module for parsing and validating microhap identifiers (see #119).
+- New `summarize` subcommand for summarizing MicroHapDB database contents (see #120).
 
 ### Changed
 - Overhaul of the marker table structure and database build procedure (see #106, #111, #112).

--- a/microhapdb/cli/__init__.py
+++ b/microhapdb/cli/__init__.py
@@ -12,7 +12,7 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
-from . import lookup, marker, population, frequency
+from . import lookup, marker, population, frequency, summarize
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import microhapdb
 from pyfaidx import Fasta as FastaIdx
@@ -26,6 +26,7 @@ subparser_funcs = {
     "marker": marker.subparser,
     "population": population.subparser,
     "frequency": frequency.subparser,
+    "summarize": summarize.subparser,
 }
 
 mains = {
@@ -33,6 +34,7 @@ mains = {
     "marker": marker.main,
     "population": population.main,
     "frequency": frequency.main,
+    "summarize": summarize.main,
 }
 
 bubbletext = r"""

--- a/microhapdb/cli/summarize.py
+++ b/microhapdb/cli/summarize.py
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2023, DHS.
+#
+# This file is part of MicroHapDB (http://github.com/bioforensics/MicroHapDB) and is licensed under
+# the BSD license: see LICENSE.txt.
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+import microhapdb
+from microhapdb import Population
+from textwrap import dedent
+
+
+def main(args):
+    num_markers = len(microhapdb.markers)
+    markers = microhapdb.Marker.objectify(microhapdb.markers)
+    num_loci = len(set([m.locus for m in markers]))
+    print("[microhaplotypes]")
+    print(f"  - {num_markers} marker defintions")
+    print(f"  - {num_loci} distinct loci")
+    num_pops = len(microhapdb.populations)
+    num_haplotypes = len(microhapdb.frequencies.groupby(["Marker", "Allele"]))
+    num_frequencies = len(microhapdb.frequencies)
+    print("[frequencies]")
+    print(f"  - {num_haplotypes} haplotypes")
+    print(f"  - {num_pops} population groups")
+    print(f"  - {num_frequencies} total microhap frequencies")
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser(
+        "summarize",
+        description="Summarize MicroHapDB database contents",
+    )

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -165,6 +165,10 @@ class Marker:
         return self.data.Name
 
     @property
+    def locus(self):
+        return self.name.split(".")[0]
+
+    @property
     def slug(self):
         seqid = self.chrom
         return f"{seqid}:{self.start+1}-{self.end}"

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -626,3 +626,21 @@ mh01NH-04.v1        3      53  chr1 230684832 230684884 3.566          Hiroaki20
     """
     print(observed)
     assert observed.strip() == expected.strip()
+
+
+def test_cli_summarize(capsys):
+    args = get_parser().parse_args(["summarize"])
+    microhapdb.cli.main(args)
+    terminal = capsys.readouterr()
+    observed = terminal.out
+    expected = """
+[microhaplotypes]
+  - 1836 marker defintions
+  - 1409 distinct loci
+[frequencies]
+  - 23671 haplotypes
+  - 125 population groups
+  - 488283 total microhap frequencies
+"""
+    print(observed)
+    assert observed.strip() == expected.strip()


### PR DESCRIPTION
```
$ microhapdb summarize
[microhaplotypes]
  - 1836 marker defintions
  - 1409 distinct loci
[frequencies]
  - 23671 haplotypes
  - 125 population groups
  - 488283 total microhap frequencies
```

Closes #113.