### PR TITLE
Fix count test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Debugged a test that counts observed haplotypes (#154).
+
+
 ## [0.11] 2023-10-25
 
 ### Added 

--- a/microhapdb/marker.py
+++ b/microhapdb/marker.py
@@ -182,11 +182,11 @@ class Marker:
 
     @property
     def start(self):
-        return self.data.Start - 1
+        return int(self.data.Start - 1)
 
     @property
     def end(self):
-        return self.data.End - 1 + self.variant_lengths[-1]
+        return int(self.data.End - 1 + self.variant_lengths[-1])
 
     @property
     def target_slug(self):

--- a/microhapdb/tests/test_frequency.py
+++ b/microhapdb/tests/test_frequency.py
@@ -118,5 +118,9 @@ def test_counts_random():
     for _ in range(5):
         random_marker = choice(microhapdb.markers.Name)
         random_population = choice(pops[pops.Source == "Byrska-Bishop2022"].ID.to_list())
-        subset = freq[(freq.Marker == random_marker) & (freq.Population == random_population)]
+        subset = freq[
+            (freq.Marker == random_marker)
+            & (freq.Population == random_population)
+            & (freq.Source == "Byrska-Bishop2022")
+        ]
         assert len(set(subset.Count)) == 1, subset


### PR DESCRIPTION
A handful of CI builds have failed recently due to a failure with the `microhapdb/tests/test_frequency.py::test_counts_random` test. This test repeats the following procedure 5 times: select a random marker; select a random population from the 1000 Genomes project; select the frequency data for that marker and population; ensure that all of the frequency data is computed from the same number of observed alleles.

The problem with the test is that the 1KGP populations have frequency data from more than one source, and therefore inconsistent count data. This PR fixes the test to make sure we're only pulling 1KGP count and frequency data for this particular test.