### PR TITLE
Drop 1KGP aggregate from population list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Debugged a test that counts observed haplotypes (#154).
-- Replaced global pooled Ae values with 26-population average as the default Ae reported (#155).
+- Replaced global pooled Ae values with 26-population average as the default Ae reported (#155, #158).
 - Replaced deprecated `pkg_resources` module with `importlib.resources` (#156).
 - Upgraded versioneer to a Python 3.12+ compatible version (#156).
 

--- a/microhapdb/__init__.py
+++ b/microhapdb/__init__.py
@@ -49,15 +49,15 @@ def retrieve_by_id(ident):
     2592  mh17KK-014        3      37  chr17  4497061  4497097  4497061;4497089;4497097  4400356;4400384;4400392  rs333113;rs8074965;rs11657785  Kidd2018  2.074
     >>> retrieve_by_id("Chagga")
                    ID    Name        Source
-    16  mMHseq-Chagga  Chagga  Gandotra2020
-    17      SA000487T  Chagga      Kidd2018
+    15  mMHseq-Chagga  Chagga  Gandotra2020
+    16      SA000487T  Chagga      Kidd2018
     >>> retrieve_by_id("Asia")
                      ID  Name          Source
-    9  MHDBP-936bc36f79  Asia  vanderGaag2018
+    8  MHDBP-936bc36f79  Asia  vanderGaag2018
     >>> retrieve_by_id("Japanese")
                       ID      Name       Source
-    54  MHDBP-63967b883e  Japanese  Hiroaki2015
-    55         SA000010B  Japanese     Kidd2018
+    53  MHDBP-63967b883e  Japanese  Hiroaki2015
+    54         SA000010B  Japanese     Kidd2018
     """
 
     def id_in_series(ident, series):

--- a/microhapdb/data/population.csv
+++ b/microhapdb/data/population.csv
@@ -1,5 +1,4 @@
 ID,Name,Source
-1KGP,1000 Genomes Aggregate,Byrska-Bishop2022
 mMHseq-Adygei,Adygei,Gandotra2020
 SA000017I,Adygei,Kidd2018
 AFR,Africa,Byrska-Bishop2022

--- a/microhapdb/population.py
+++ b/microhapdb/population.py
@@ -30,7 +30,7 @@ class Population:
     SA000010B       Japanese        Kidd2018
     JPT     Japanese in Tokyo, Japan        Byrska-Bishop2022
     >>> microhapdb.populations.shape
-    (125, 3)
+    (124, 3)
     """
 
     def __init__(self, popid, name, source):

--- a/microhapdb/tests/test_cli.py
+++ b/microhapdb/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_main_pop_noargs(capsys):
     microhapdb.cli.main(args)
     out, err = capsys.readouterr()
     outlines = out.strip().split("\n")
-    assert len(outlines) == 1 + 125
+    assert len(outlines) == 1 + 124
 
 
 def test_main_pop_detail(capsys):
@@ -689,7 +689,7 @@ def test_cli_summarize(capsys):
   - 2413 distinct loci
 [frequencies]
   - 59753 haplotypes
-  - 125 population groups
+  - 124 population groups
   - 885503 total microhap frequencies
 """
     print(observed)

--- a/microhapdb/tests/test_population.py
+++ b/microhapdb/tests/test_population.py
@@ -29,7 +29,7 @@ def test_standardize_ids():
 
 def test_assumptions():
     num_populations_per_source = [
-        31,  # Byrska-Bishop2022
+        30,  # Byrska-Bishop2022
         1,  # Chen2019
         7,  # Gandotra2020
         1,  # Hiroaki2015
@@ -49,8 +49,8 @@ def test_populations():
     SA000040E Kachari Kidd2018
     >>> Population.table_from_ids(["EAS", "SAS"])
           ID        Name             Source
-    27   EAS   East Asia  Byrska-Bishop2022
-    104  SAS  South Asia  Byrska-Bishop2022
+    26   EAS   East Asia  Byrska-Bishop2022
+    103  SAS  South Asia  Byrska-Bishop2022
     >>> for pop in Population.from_query("Name.str.contains('Han')"):
     ...   print(pop.popid, pop.name, pop.source)
     ChengduHan Chengdu Han Zou2022
@@ -62,14 +62,14 @@ def test_populations():
     CHS Southern Han Chinese Byrska-Bishop2022
     >>> Population.table_from_query("Name.str.contains('Afr')")
                      ID                                     Name             Source
-    3               AFR                                   Africa  Byrska-Bishop2022
-    4  MHDBP-3dab7bdd14                                   Africa     vanderGaag2018
-    5         SA000101C                        African Americans           Kidd2018
-    6               ACB           African Caribbeans in Barbados  Byrska-Bishop2022
-    7               ASW  Americans of African Ancestry in SW USA  Byrska-Bishop2022
+    2               AFR                                   Africa  Byrska-Bishop2022
+    3  MHDBP-3dab7bdd14                                   Africa     vanderGaag2018
+    4         SA000101C                        African Americans           Kidd2018
+    5               ACB           African Caribbeans in Barbados  Byrska-Bishop2022
+    6               ASW  Americans of African Ancestry in SW USA  Byrska-Bishop2022
     """
     pop = microhapdb.populations
-    assert pop.shape == (125, 3)
+    assert pop.shape == (124, 3)
     assert Population.from_id("MHDBP-7c055e7ee8").name == "Swedish"
     assert Population.from_id("SA000028K").name == "Karitiana"
     result = Population.table_from_query("Name.str.contains('Jews')")


### PR DESCRIPTION
A failure of the `microhapdb/tests/test_frequency.py::test_counts_random` test today uncovered an issue.

In #155, aggregation of all 1000 Genomes Project data into a single global superpopulation (1KGP) was discontinued. (1KGP was kept around as a label for the average of the 26 global population groups when calculating Ae.) However, 1KGP is still listed as an entry in the `populations` table, causing this test to fail intermittently whenever that entry is chosen for a random test.

This PR removes 1KGP from the populations table and updates all of the tests accordingly.